### PR TITLE
Add PHP 7.3 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ language: php
 php:
   - 7.1
   - 7.2
+  - 7.3
 
 cache:
   directories:
@@ -29,7 +30,7 @@ branches:
     - /^\d.\d+-release$/
 
 before_script:
-  - phpenv config-rm xdebug.ini
+  - phpenv config-rm xdebug.ini || true
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
   # Read-only OAuth token to work around GitHub API rate limits


### PR DESCRIPTION
Requires https://github.com/travis-ci/travis-ci/issues/9717 to merge, but let's see what happens.