### PR TITLE
Fix unitialized typed property in backend

### DIFF
--- a/lib/Backend/EzPlatformBackend.php
+++ b/lib/Backend/EzPlatformBackend.php
@@ -366,7 +366,7 @@ final class EzPlatformBackend implements BackendInterface
             return true;
         }
 
-        if ($this->allowedContentTypes === null) {
+        if (!isset($this->allowedContentTypes)) {
             $this->allowedContentTypes = [];
 
             $allowedContentTypes = $this->config->getParameter('allowed_content_types');


### PR DESCRIPTION
Typed property `allowedContentTypes` is not initialized so it will throw an error when using it in if.